### PR TITLE
chore: add support for recording runtime traces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ interface Opts {
     readonly fast?: number;
 
     readonly verbose?: boolean;
+    readonly runtimeTrace?: boolean;
 }
 
 const Constants = {
@@ -142,6 +143,10 @@ async function runPerformanceTest(opts: Opts): Promise<void> {
     }
     if (opts.verbose) {
         args.push('--verbose');
+    }
+    if (opts.runtimeTrace) {
+        // Collects metrics for loading, navigation and v8 script compilation phases.
+        args.push('--runtime-trace-categories="benchmark,browser,content,loading,navigation,mojom,renderer_host,startup,toplevel,v8,disabled-by-default-loading,disabled-by-default-network,disabled-by-default-v8.compile"');
     }
 
     return new Promise(resolve => {
@@ -313,7 +318,8 @@ module.exports = async function (argv: string[]): Promise<void> {
         .option('--slack-token <token>', `a Slack token for writing Slack messages`)
         .option('--slack-message-threads <filepath>', `a file in which commit -> message thread mappings are stored`)
         .option('-f, --fast <number>', 'what time is considered a fast performance run')
-        .option('-v, --verbose', 'logs verbose output to the console when errors occur');
+        .option('-v, --verbose', 'logs verbose output to the console when errors occur')
+        .option('--runtime-trace', 'enable startup tracing of the runtime');
 
     const opts: Opts = program.parse(argv).opts();
     if (opts.fast) {


### PR DESCRIPTION
Triggers runtime trace when `--runtime-trace` is passed. Traces will be collected at `<path-to>\vscode-perf\vscode-runtime-traces`