### PR TITLE
update thread when better duration is met

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/vscode-perf-bot",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Allows to run performance tests with Slack bot messages for VS Code.",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This will make sure that the main message in the performance channel always reflects the best of the runs if there are multiple runs for the same commit. That way, you do not have to drill into the thread to find the best run.

Uses a trick to store the best run as part of the metadata of a message thread.