### PR TITLE
feat: support uploading runtime trace files to slack

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "commander": "^9.4.0"
     },
     "devDependencies": {
-        "@types/node": "18.x",
+        "@types/node": "20.x",
         "typescript": "5.4.x"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,10 +146,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@18.x":
-  version "18.11.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
-  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+"@types/node@20.x":
+  version "20.17.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.19.tgz#0f2869555719bef266ca6e1827fcdca903c1a697"
+  integrity sha512-LEwC7o1ifqg/6r2gn9Dns0f1rhK+fPFDoMiceTJ6kWmVk6bgXBI/9IOWfVan4WiAavK9pIVWdX0/e3J+eEUh5A==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/retry@0.12.0":
   version "0.12.0"
@@ -362,6 +364,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This extends our existing infra to record runtime traces to actually upload the trace file to the message thread. This will help diagnose issues like https://github.com/microsoft/vscode/pull/241640#issuecomment-2683870621 and other runtime specific issues arising from the perf infra.

Following changes are made,

1) Default trace categories are updated to capture the relevant metrics that impact startup
2) When `--runtime-trace` option is used, the trace file from the run that has `bestDuration` in the current session will get uploaded to the slack message thread.

Here is it in action,

<img width="778" alt="Screenshot 2025-02-26 at 18 33 32" src="https://github.com/user-attachments/assets/f25de41b-9cea-453e-a07d-8bc05a39f2b6" />


**TODO before deploying**

- [ ] The upload call requires the `file:write` scope on the PerfBot App, need admin on VS Code repo to update and reinstall the application.
- [ ] Have `--runtime-trace` specified when using this module from the perf bot.